### PR TITLE
chore: add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+CONSUL=127.0.0.1:8500
+BROKER_ADDRESS=amqp://admin:admin@rabbit:5672?heartbeat=10
+DATASOURCE=postgres://postgres:postgres@postgres:5432/webitel?application_name=logger&sslmode=disable&connect_timeout=10
+GRPC_ADDR=127.0.0.1:10011
+
+# SERVICE_ID=1
+
+# LOGIN_CONSUMPTION=true
+# CRUD_EVENTS=false


### PR DESCRIPTION
Adds a documented `.env.example` (env names from `internal/model/app_config.go`). Reference/groundwork for the env migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)