### PR TITLE
ref(systemd): harden unit and move config to env files

### DIFF
--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -2,17 +2,19 @@ package logger
 
 import (
 	"context"
-	"github.com/BoRuDar/configuration/v4"
-	"github.com/webitel/logger/internal/app"
-	"github.com/webitel/logger/internal/model"
-	otelsdk "github.com/webitel/webitel-go-kit/infra/otel/sdk"
-	"go.opentelemetry.io/contrib/bridges/otelslog"
-	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/BoRuDar/configuration/v4"
+	otelsdk "github.com/webitel/webitel-go-kit/infra/otel/sdk"
+	"go.opentelemetry.io/contrib/bridges/otelslog"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"github.com/webitel/logger/internal/app"
+	"github.com/webitel/logger/internal/model"
 
 	// -------------------- plugin(s) -------------------- //
 	_ "github.com/webitel/webitel-go-kit/infra/otel/sdk/log/otlp"
@@ -25,7 +27,7 @@ import (
 
 const (
 	name      = "logger"
-	version   = "25.05"
+	version   = "26.02"
 	namespace = "webitel"
 )
 

--- a/deploy/systemd/webitel-logger.service
+++ b/deploy/systemd/webitel-logger.service
@@ -1,13 +1,69 @@
 [Unit]
-Description=Webitel Logger Service
-After=network.target
+Description=Webitel Logger
+After=network.target consul.service rabbitmq-server.service postgresql.service
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
-ExecStart=webitel-logger -id 20 \
-	-consul 127.0.0.1:8500 \
-    -grpc_addr 127.0.0.1:10011 \
-    -amqp amqp://webitel:webitel@127.0.0.1:5672?heartbeat=10 \
-	-data_source postgres://opensips:webitel@127.0.0.1:5432/webitel?application_name=logger&sslmode=disable&connect_timeout=10
+Type=simple
+User=webitel
+Group=webitel
+
+EnvironmentFile=/etc/default/webitel-logger
+EnvironmentFile=-/etc/default/webitel-otel
+EnvironmentFile=-/etc/default/webitel
+ExecStart=/usr/local/bin/webitel-logger
+
+Restart=on-failure
+RestartSec=5
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStartSec=0
+TimeoutStopSec=30
+LimitNOFILE=64000
+LimitNPROC=4096
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=webitel-logger
+
+# Filesystem isolation
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+NoExecPaths=/
+ExecPaths=/usr/local/bin/webitel-logger
+
+# Process isolation
+PrivateDevices=yes
+PrivateUsers=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectProc=invisible
+ProcSubset=pid
+NoNewPrivileges=yes
+PrivateMounts=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectHostname=yes
+MemoryDenyWriteExecute=yes
+SystemCallArchitectures=native
+UMask=0077
+
+# Capabilities & syscalls
+CapabilityBoundingSet=
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+SystemCallFilter=~@obsolete
+SystemCallErrorNumber=EPERM
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Standardize systemd units across services:

- Apply consistent security sandboxing (filesystem/process isolation, syscall filters, capability bounding).
- Drop inline ExecStart flags; configuration now lives in per-unit `/etc/default/<unit>` (EnvironmentFile).
- Fix binary path to `/usr/local/bin/<service>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)